### PR TITLE
Add logging system, INFO messages at each step start & stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added logging system with messages at start and stop of each step.
 
 ## [0.2.1] - 2025-08-25
 


### PR DESCRIPTION
This PR does a couple things:

- Adds a simple logging system in the CLI.
- Adds INFO messages at app start and stop
- Adds INFO messages at start/stop of each step of the app.

I understand some steps can take time to run so it's nice to give the user feedback that a step is still ongoing. I'm not sure if this is too much detail.

By default logging is at the INFO level. At the cli users can use `--debug` option to set the level to DEBUG.

In this PR, messages are output to stdout like:

```
INFO:tlm_sterodynamics.cli:Starting tlm-sterodynamics
INFO:tlm_sterodynamics.cli:Starting thermal expansion preprocessing
INFO:tlm_sterodynamics.cli:Thermal expansion preprocessing complete
INFO:tlm_sterodynamics.cli:Starting ocean dynamics preprocessing
INFO:tlm_sterodynamics.cli:Ocean dynamics preprocessing complete
INFO:tlm_sterodynamics.cli:Starting thermal expansion fitting
INFO:tlm_sterodynamics.cli:Thermal expansion fitting complete
INFO:tlm_sterodynamics.cli:Starting ocean dynamics fitting
INFO:tlm_sterodynamics.cli:Ocean dynamics fitting complete
INFO:tlm_sterodynamics.cli:Starting thermal expansion projection
INFO:tlm_sterodynamics.cli:Thermal expansion projection complete
INFO:tlm_sterodynamics.cli:Starting ocean dynamics postprocessing
INFO:tlm_sterodynamics.cli:Ocean dynamics postprocessing complete
INFO:tlm_sterodynamics.cli:tlm-sterodynamics complete
```

before, this would have just been

```
Hello from tlm-sterodynamics!
```
I also added an entry to the changelog.
