### PR TITLE
make lslr optional + update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ docker run --rm \
 
 If the run is successful, the output projection will appear in `./data/output`.
 
+The above example will produce both global and localized output projections. You can skip the localization step and only produce global outputs by omitting the `output-lslr-file` input argument:
+
+```shell
+docker run --rm \
+  -v ./data/input:/input/:ro \
+  -v ./data/output:/output \
+  ghcr.io/fact-sealevel/tlm-sterodynamics:latest \
+  --pipeline-id=1234 \
+  --scenario="ssp585" \
+  --nsamps=1000 \
+  --output-gslr-file="/output/gslr.nc" \
+  --climate-data-file="/input/climate.nc" \
+  --location-file="/input/location.lst" \
+  --model-dir="/input/cmip6/" \
+  --expansion-coefficients-file="/input/scmpy2LM_RCMIP_CMIP6calpm_n18_expcoefs.nc" \
+  --gsat-rmses-file="/input/scmpy2LM_RCMIP_CMIP6calpm_n17_gsat_rmse.nc"
+  ```
+
 > [!TIP]
 > For this example we use `ghcr.io/fact-sealevel/tlm-sterodynamics:latest`. We do not recommend using `latest` for production runs because it will grab the latest release. This means runs will not be reproducible and may include breaking changes. Instead, use a tag for a specific version of the image or an image's digest hash. You can find tagged image versions and digests [here](https://github.com/fact-sealevel/tlm-sterodynamics/pkgs/container/tlm-sterodynamics).
 

--- a/src/tlm_sterodynamics/cli.py
+++ b/src/tlm_sterodynamics/cli.py
@@ -250,6 +250,8 @@ def main(
         )
         logger.info("Ocean dynamics postprocessing complete")
     else:
-        logger.info("No output local SLR file provided, skipping ocean dynamics postprocessing")
+        logger.info(
+            "No output local SLR file provided, skipping ocean dynamics postprocessing"
+        )
 
     logger.info("tlm-sterodynamics complete")

--- a/src/tlm_sterodynamics/cli.py
+++ b/src/tlm_sterodynamics/cli.py
@@ -44,7 +44,7 @@ logging.basicConfig(level=logging.INFO)
     "--output-lslr-file",
     envvar="TLM_STERODYNAMICS_OUTPUT_LSLR_FILE",
     help="Path to write output local SLR file.",
-    required=True,
+    required=False,
     type=str,
 )
 @click.option(
@@ -236,17 +236,20 @@ def main(
     )
     logger.info("Thermal expansion projection complete")
 
-    logger.info("Starting ocean dynamics postprocessing")
-    tlm_postprocess_oceandynamics(
-        od_config,
-        od_zos,
-        od_oceandynamics_fit,
-        te_projections,
-        nsamps,
-        seed,
-        chunksize,
-        output_lslr_file,
-    )
-    logger.info("Ocean dynamics postprocessing complete")
+    if output_lslr_file:
+        logger.info("Starting ocean dynamics postprocessing")
+        tlm_postprocess_oceandynamics(
+            od_config,
+            od_zos,
+            od_oceandynamics_fit,
+            te_projections,
+            nsamps,
+            seed,
+            chunksize,
+            output_lslr_file,
+        )
+        logger.info("Ocean dynamics postprocessing complete")
+    else:
+        logger.info("No output local SLR file provided, skipping ocean dynamics postprocessing")
 
     logger.info("tlm-sterodynamics complete")


### PR DESCRIPTION
This PR makes the input argument `output-lslr-file` optional and skips the localization/fingerprinting postprocessing step if it is not passed. There is more discussion about this in https://github.com/fact-sealevel/facts-experiment-builder/issues/70. This ran successfully for me in a container with a locally built image that included the fix.